### PR TITLE
ie 11 blur issue fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,14 +140,14 @@ module.exports =
 
 	            if (this.state.inputFocus) {
 	                this.refs.input.focus();
-	            }
+					
+					if (this.state.selectionStart || this.state.selectionStart === 0) {
+						this.refs.input.selectionStart = this.state.selectionStart;
+					}
 
-	            if (this.state.selectionStart || this.state.selectionStart === 0) {
-	                this.refs.input.selectionStart = this.state.selectionStart;
-	            }
-
-	            if (this.state.selectionEnd || this.state.selectionEnd === 0) {
-	                this.refs.input.selectionEnd = this.state.selectionEnd;
+					if (this.state.selectionEnd || this.state.selectionEnd === 0) {
+						this.refs.input.selectionEnd = this.state.selectionEnd;
+					}
 	            }
 
 	            this.checkValidity();

--- a/src/NumericInput.jsx
+++ b/src/NumericInput.jsx
@@ -365,16 +365,16 @@ class NumericInput extends Component
         // this.state.inputFocus to true)
         if (this.state.inputFocus) {
             this.refs.input.focus()
-        }
 
-        // Restore selectionStart (if any)
-        if (this.state.selectionStart || this.state.selectionStart === 0) {
-            this.refs.input.selectionStart = this.state.selectionStart
-        }
+            // Restore selectionStart (if any)
+            if (this.state.selectionStart || this.state.selectionStart === 0) {
+                this.refs.input.selectionStart = this.state.selectionStart
+            }
 
-        // Restore selectionEnd (if any)
-        if (this.state.selectionEnd || this.state.selectionEnd === 0) {
-            this.refs.input.selectionEnd = this.state.selectionEnd
+            // Restore selectionEnd (if any)
+            if (this.state.selectionEnd || this.state.selectionEnd === 0) {
+                this.refs.input.selectionEnd = this.state.selectionEnd
+            }
         }
 
         this.checkValidity()


### PR DESCRIPTION
There's an issue in IE11, described by superfunkminister:
"I can type into the input, but can't seem to move to another field once I've finished typing - the cursor seems to get stuck."

Issue is caused by changing selectionStart and selectionEnd input properties with every component update, no matter if input is focused or not. Under IE11 changing this properties cause input focusing.