### PR TITLE
Support custom input component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-numeric-input",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Number input component that can replace the native number input which is not yet very well supported and where it is, it does not have the same appearance across the browsers. Additionally this component offers more flexible options and can be used for any values (differently formatted representations of the internal numeric value).",
   "main": "index.js",
   "scripts": {

--- a/src/NumericInput.jsx
+++ b/src/NumericInput.jsx
@@ -1112,11 +1112,13 @@ class NumericInput extends Component
                 Object.assign(attrs.input.style, css['input:disabled'])
             }
         }
+        
+        const InputTag = props.componentClass || 'input';
 
         if (mobile) {
             return (
                 <span {...attrs.wrap}>
-                    <input {...attrs.input}/>
+                    <InputTag {...attrs.input}/>
                     <b {...attrs.btnUp}>
                         <i style={ style === false ? null : css.minus }/>
                         <i style={ style === false ? null : css.plus }/>
@@ -1130,7 +1132,7 @@ class NumericInput extends Component
 
         return (
             <span {...attrs.wrap}>
-                <input {...attrs.input}/>
+                <InputTag {...attrs.input}/>
                 <b {...attrs.btnUp}>
                     <i style={ style === false ? null : css.arrowUp }/>
                 </b>


### PR DESCRIPTION
Added support for the variable input component, similar to how to react-bootstrap using componentClass prop.

Example: `<NumericInput componentClass={CustomInput} />`

Fixes #64 