### PR TITLE
input styling overrides input:not(.form-control) styling

### DIFF
--- a/dist/react-numeric-input.js
+++ b/dist/react-numeric-input.js
@@ -792,7 +792,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                        }
 	                    },
 	                    type: 'text',
-	                    style: noStyle ? null : _extends({}, css.input, !hasFormControl ? css['input:not(.form-control)'] : {}, this._inputFocus ? css['input:focus'] : {})
+	                    style: noStyle ? null : _extends({}, css.input, !hasFormControl && !style.input ? css['input:not(.form-control)'] : {}, this._inputFocus ? css['input:focus'] : {})
 	                }, rest),
 	                btnUp: {
 	                    onMouseEnter: undefined,
@@ -1231,7 +1231,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        fontSize: 'inherit'
 	    },
 
-	    // The input with bootstrap class
+	    // The input without bootstrap class
 	    'input:not(.form-control)': {
 	        border: '1px solid #ccc',
 	        borderRadius: 2,

--- a/docs/react-numeric-input.js
+++ b/docs/react-numeric-input.js
@@ -792,7 +792,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	                        }
 	                    },
 	                    type: 'text',
-	                    style: noStyle ? null : _extends({}, css.input, !hasFormControl ? css['input:not(.form-control)'] : {}, this._inputFocus ? css['input:focus'] : {})
+	                    style: noStyle ? null : _extends({}, css.input, !hasFormControl && !style.input ? css['input:not(.form-control)'] : {}, this._inputFocus ? css['input:focus'] : {})
 	                }, rest),
 	                btnUp: {
 	                    onMouseEnter: undefined,
@@ -1231,7 +1231,7 @@ return /******/ (function(modules) { // webpackBootstrap
 	        fontSize: 'inherit'
 	    },
 
-	    // The input with bootstrap class
+	    // The input without bootstrap class
 	    'input:not(.form-control)': {
 	        border: '1px solid #ccc',
 	        borderRadius: 2,

--- a/index.js
+++ b/index.js
@@ -534,7 +534,7 @@ module.exports =
 	                        }
 	                    },
 	                    type: 'text',
-	                    style: noStyle ? null : _extends({}, css.input, !hasFormControl ? css['input:not(.form-control)'] : {}, this._inputFocus ? css['input:focus'] : {})
+	                    style: noStyle ? null : _extends({}, css.input, !hasFormControl && !style.input ? css['input:not(.form-control)'] : {}, this._inputFocus ? css['input:focus'] : {})
 	                }, rest),
 	                btnUp: {
 	                    onMouseEnter: undefined,

--- a/src/NumericInput.jsx
+++ b/src/NumericInput.jsx
@@ -270,7 +270,7 @@ class NumericInput extends Component
             fontSize    : 'inherit'
         },
 
-        // The input with bootstrap class
+        // The input without bootstrap class
         'input:not(.form-control)': {
             border           : '1px solid #ccc',
             borderRadius     : 2,
@@ -894,7 +894,7 @@ class NumericInput extends Component
                 style: noStyle ? null : Object.assign(
                     {},
                     css.input,
-                    !hasFormControl ?
+                    !hasFormControl && !style.input ?
                         css['input:not(.form-control)'] :
                         {},
                     this._inputFocus ? css['input:focus'] : {}


### PR DESCRIPTION
Previously, users not using the "form-control" class on their input would have their "input" style prop being overridden by the "input:not(.form-control)" default styling. For instance, border and border-radius could not be changed using only the "input" style prop. The only way to style an input if not using bootstrap was to use "input:not(.form-control)" style prop. The label for "input:not(.form-control)" style was also incorrectly stated as "The input with bootstrap class".

This PR fixes this by only implementing "input:not(.form-control)" default styling if no "input" style prop is provided, making it much more intuitive to use. The typo for "input:not(.form-control)" is also corrected to "The input without bootstrap class".